### PR TITLE
fix(portal): add rehype-sanitize XSS protection

### DIFF
--- a/web-portal/package-lock.json
+++ b/web-portal/package-lock.json
@@ -37,6 +37,7 @@
         "react-resizable-panels": "^2.1.9",
         "react-router-dom": "^7.13.1",
         "rehype-highlight": "^7.0.2",
+        "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "shiki": "^4.0.2",
         "sonner": "^2.0.7",
@@ -4456,6 +4457,21 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
@@ -6819,6 +6835,20 @@
         "lowlight": "^3.0.0",
         "unist-util-visit": "^5.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/web-portal/package.json
+++ b/web-portal/package.json
@@ -42,6 +42,7 @@
     "react-resizable-panels": "^2.1.9",
     "react-router-dom": "^7.13.1",
     "rehype-highlight": "^7.0.2",
+    "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "shiki": "^4.0.2",
     "sonner": "^2.0.7",

--- a/web-portal/src/components/ChatMessage.tsx
+++ b/web-portal/src/components/ChatMessage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import rehypeHighlight from 'rehype-highlight'
+import rehypeSanitize from 'rehype-sanitize'
 import type { Components } from 'react-markdown'
 import type { Attachment, ChatMessage as ChatMessageType } from '../types/messages'
 import VoiceOutput from './VoiceOutput'
@@ -11,7 +12,7 @@ import { CopyButton } from './ui/copy-button'
 import { formatTimeAgo } from '../utils/format'
 
 const REMARK_PLUGINS = [remarkGfm]
-const REHYPE_PLUGINS = [rehypeHighlight]
+const REHYPE_PLUGINS = [rehypeHighlight, rehypeSanitize]
 
 interface ChatMessageProps {
   message: ChatMessageType


### PR DESCRIPTION
## Summary
- Add `rehype-sanitize` plugin to ReactMarkdown's rehype pipeline in `ChatMessage.tsx` to prevent XSS attacks from malicious LLM output
- Plugin runs after `rehype-highlight` so syntax highlighting CSS classes are preserved while dangerous HTML (script, iframe, event handlers) is stripped
- All 8 existing ChatMessage tests pass without modification

## Test plan
- [x] `npx vitest run src/components/ChatMessage` -- 8/8 tests pass
- [x] TypeScript typecheck passes with no errors
- [x] Code review (simplify) confirms minimal, clean change

🤖 Generated with [Claude Code](https://claude.com/claude-code)