### PR TITLE
feat(providers): add HTTP 529/503 overload detection to recordProviderHealthFailure

### DIFF
--- a/src/agents/orchestrator-runtime-utils.test.ts
+++ b/src/agents/orchestrator-runtime-utils.test.ts
@@ -4,6 +4,7 @@ import {
   mergeLearnedInsights,
   normalizeFailureFingerprint,
   parseReflectionDecision,
+  recordProviderHealthFailure,
   replaceSection,
   sanitizeEventInput,
   sanitizeToolResult,
@@ -183,5 +184,57 @@ describe("classifyStepErrorCategory", () => {
 
   it("handles empty/falsy input", () => {
     expect(classifyStepErrorCategory("")).toBe("unknown");
+  });
+});
+
+describe("recordProviderHealthFailure", () => {
+  function createMockRegistry() {
+    return {
+      recordFailure: (_name: string, _error: string) => {},
+      recordQuotaExhausted: (_name: string, _error: string) => {},
+      recordOverloaded: (_name: string, _error: string) => {},
+    };
+  }
+
+  it("routes 403 quota errors to recordQuotaExhausted", () => {
+    const reg = createMockRegistry();
+    const spy = { called: "" };
+    reg.recordQuotaExhausted = (name: string) => { spy.called = name; };
+    recordProviderHealthFailure(reg, "openai", "403 quota exceeded");
+    expect(spy.called).toBe("openai");
+  });
+
+  it("routes HTTP 529 errors to recordOverloaded", () => {
+    const reg = createMockRegistry();
+    const spy = { called: "" };
+    reg.recordOverloaded = (name: string) => { spy.called = name; };
+    recordProviderHealthFailure(reg, "minimax", "Request failed with status 529");
+    expect(spy.called).toBe("minimax");
+  });
+
+  it("routes HTTP 503 errors to recordOverloaded", () => {
+    const reg = createMockRegistry();
+    const spy = { called: "" };
+    reg.recordOverloaded = (name: string) => { spy.called = name; };
+    recordProviderHealthFailure(reg, "anthropic", "Service Unavailable 503");
+    expect(spy.called).toBe("anthropic");
+  });
+
+  it("routes generic errors to recordFailure", () => {
+    const reg = createMockRegistry();
+    const spy = { called: "" };
+    reg.recordFailure = (name: string) => { spy.called = name; };
+    recordProviderHealthFailure(reg, "openai", "Connection timeout");
+    expect(spy.called).toBe("openai");
+  });
+
+  it("does not treat 403 without quota keywords as quota exhaustion", () => {
+    const reg = createMockRegistry();
+    const spy = { failure: false, quota: false };
+    reg.recordFailure = () => { spy.failure = true; };
+    reg.recordQuotaExhausted = () => { spy.quota = true; };
+    recordProviderHealthFailure(reg, "openai", "403 Forbidden");
+    expect(spy.failure).toBe(true);
+    expect(spy.quota).toBe(false);
   });
 });

--- a/src/agents/orchestrator-runtime-utils.ts
+++ b/src/agents/orchestrator-runtime-utils.ts
@@ -236,12 +236,14 @@ export function checkProviderFailureCircuitBreaker(
  * Matches the same quota-detection logic used in fallback-chain.ts.
  */
 export function recordProviderHealthFailure(
-  registry: { recordFailure(name: string, error: string): void; recordQuotaExhausted(name: string, error: string): void },
+  registry: { recordFailure(name: string, error: string): void; recordQuotaExhausted(name: string, error: string): void; recordOverloaded(name: string, error: string): void },
   providerName: string,
   errorMsg: string,
 ): void {
   if (/\b403\b/.test(errorMsg) && QUOTA_LIMIT_RE.test(errorMsg)) {
     registry.recordQuotaExhausted(providerName, errorMsg);
+  } else if (/\b(?:529|503)\b/.test(errorMsg)) {
+    registry.recordOverloaded(providerName, errorMsg);
   } else {
     registry.recordFailure(providerName, errorMsg);
   }

--- a/src/agents/providers/provider-health.ts
+++ b/src/agents/providers/provider-health.ts
@@ -127,6 +127,29 @@ export class ProviderHealthRegistry {
   }
 
   /**
+   * Record an overloaded response (HTTP 529/503) — sets a moderate cooldown
+   * (5 minutes) so the provider has time to recover from load.
+   */
+  recordOverloaded(providerName: string, error: string): void {
+    const normalized = providerName.trim().toLowerCase();
+    const existing = this.entries.get(normalized);
+    const now = Date.now();
+    const OVERLOAD_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes
+
+    // Don't extend an existing active cooldown — keep the original expiry
+    const existingCooldown = existing?.cooldownUntil ?? 0;
+    const cooldownUntil = existingCooldown > now ? existingCooldown : now + OVERLOAD_COOLDOWN_MS;
+
+    this.entries.set(normalized, {
+      status: "down",
+      consecutiveFailures: this.nextFailureCount(normalized),
+      lastFailureAt: now,
+      lastError: error.slice(0, 200),
+      cooldownUntil,
+    });
+  }
+
+  /**
    * Record a quota/billing exhaustion — sets a long cooldown (8 hours)
    * so the provider is not retried until the quota resets.
    */


### PR DESCRIPTION
## Summary
- Add `recordOverloaded()` method to `ProviderHealthRegistry` with a 5-minute cooldown for HTTP 529/503 overloaded responses
- Update `recordProviderHealthFailure` helper to detect HTTP 529/503 status codes and route to `recordOverloaded()`
- Add 5 unit tests covering all routing branches (quota, overload 529, overload 503, generic failure, 403 without quota keywords)

## Test plan
- [x] All 22 tests in `orchestrator-runtime-utils.test.ts` pass
- [x] TypeScript typecheck passes with no errors
- [x] Code reviewed via simplify for reuse, quality, and efficiency

🤖 Generated with [Claude Code](https://claude.com/claude-code)