### PR TITLE
fix(delegation): add provider health gate to prevent thundering herd

### DIFF
--- a/src/agents/multi/delegation/delegation-manager.test.ts
+++ b/src/agents/multi/delegation/delegation-manager.test.ts
@@ -11,6 +11,7 @@ import type { DelegationManagerOptions } from "./delegation-manager.js";
 import { DelegationLog } from "./delegation-log.js";
 import { TierRouter } from "./tier-router.js";
 import { createProvider } from "../../providers/provider-registry.js";
+import { ProviderHealthRegistry } from "../../providers/provider-health.js";
 import type {
   DelegationConfig,
   DelegationRequest,
@@ -756,6 +757,102 @@ describe("DelegationManager", () => {
       };
 
       await expect(manager.delegate(request)).rejects.toThrow("Unknown delegation type");
+    });
+  });
+
+  describe("provider health gate", () => {
+    let healthRegistry: InstanceType<typeof ProviderHealthRegistry>;
+
+    beforeEach(() => {
+      ProviderHealthRegistry.resetInstance();
+      healthRegistry = ProviderHealthRegistry.getInstance();
+    });
+
+    afterEach(() => {
+      ProviderHealthRegistry.resetInstance();
+    });
+
+    it("rejects delegation when all tracked providers are down", async () => {
+      // Mark two providers as down — requires 5 consecutive failures (default downThreshold)
+      for (let i = 0; i < 5; i++) {
+        healthRegistry.recordFailure("deepseek", "HTTP 529 overloaded");
+        healthRegistry.recordFailure("claude", "HTTP 529 overloaded");
+      }
+
+      const request: DelegationRequest = {
+        type: "code_review",
+        task: "Review this code",
+        parentAgentId: PARENT_AGENT_ID,
+        depth: 0,
+        mode: "sync",
+        toolContext: TEST_TOOL_CONTEXT,
+      };
+
+      await expect(manager.delegate(request)).rejects.toThrow(
+        "All providers are in cooldown",
+      );
+    });
+
+    it("allows delegation when at least one provider is healthy", async () => {
+      // Mark one provider as down (5 failures)
+      for (let i = 0; i < 5; i++) {
+        healthRegistry.recordFailure("deepseek", "HTTP 529 overloaded");
+      }
+      // Give claude a failure then recover it — ensures it has an entry with healthy status
+      healthRegistry.recordFailure("claude", "transient error");
+      healthRegistry.recordSuccess("claude");
+
+      const request: DelegationRequest = {
+        type: "code_review",
+        task: "Review this code",
+        parentAgentId: PARENT_AGENT_ID,
+        depth: 0,
+        mode: "sync",
+        toolContext: TEST_TOOL_CONTEXT,
+      };
+
+      // Should NOT throw the health gate error (may throw other errors since it's a test mock, that's fine)
+      await expect(manager.delegate(request)).resolves.toBeDefined();
+    });
+
+    it("allows delegation when no providers are tracked yet", async () => {
+      // Fresh registry with zero entries — should not block
+      const request: DelegationRequest = {
+        type: "code_review",
+        task: "Review this code",
+        parentAgentId: PARENT_AGENT_ID,
+        depth: 0,
+        mode: "sync",
+        toolContext: TEST_TOOL_CONTEXT,
+      };
+
+      await expect(manager.delegate(request)).resolves.toBeDefined();
+    });
+
+    it("isDelegationProviderAvailable returns false for down providers", async () => {
+      // Mark deepseek as down — requires 5 consecutive failures (default downThreshold)
+      for (let i = 0; i < 5; i++) {
+        healthRegistry.recordFailure("deepseek", "HTTP 529 overloaded");
+      }
+
+      // Build a manager with only deepseek key — deepseek should be unavailable
+      const healthOpts = buildManagerOpts({
+        delegationLog,
+        apiKeys: { deepseek: "test-key" },
+      });
+      const healthManager = new DelegationManager(healthOpts);
+
+      const request: DelegationRequest = {
+        type: "code_review",
+        task: "Review this code",
+        parentAgentId: PARENT_AGENT_ID,
+        depth: 0,
+        mode: "sync",
+        toolContext: TEST_TOOL_CONTEXT,
+      };
+
+      // The provider resolution should fail because deepseek is down and no other provider has a key
+      await expect(healthManager.delegate(request)).rejects.toThrow();
     });
   });
 });

--- a/src/agents/multi/delegation/delegation-manager.ts
+++ b/src/agents/multi/delegation/delegation-manager.ts
@@ -35,6 +35,7 @@ import { createProvider, PROVIDER_PRESETS } from "../../providers/provider-regis
 import { ProviderManager } from "../../providers/provider-manager.js";
 import { Orchestrator } from "../../orchestrator.js";
 import { getProviderIntelligenceSnapshot, type ProviderWorkload } from "../../providers/provider-knowledge.js";
+import { ProviderHealthRegistry } from "../../providers/provider-health.js";
 import { WorkspaceLeaseManager } from "../workspace-lease-manager.js";
 
 // =============================================================================
@@ -224,6 +225,20 @@ export class DelegationManager {
     effectiveTier: ModelTier;
   } {
     const typeConfig = this.resolveTypeConfig(request.type);
+
+    // Health gate: prevent thundering herd against overloaded providers
+    const healthRegistry = ProviderHealthRegistry.getInstance();
+    const allEntries = healthRegistry.getAllEntries();
+    if (allEntries.size > 0) {
+      const now = Date.now();
+      const allDown = [...allEntries.values()].every(
+        (e) => e.status === "down" && now < e.cooldownUntil,
+      );
+      if (allDown) {
+        throw new Error("All providers are in cooldown — delegation skipped to prevent thundering herd");
+      }
+    }
+
     // Atomically check + reserve concurrency slot to prevent TOCTOU race
     this.acquireConcurrencySlot(request.parentAgentId);
 
@@ -668,6 +683,11 @@ export class DelegationManager {
   private isDelegationProviderAvailable(name: string): boolean {
     if (this.isVerifiedLocalProvider(name)) {
       return true;
+    }
+
+    // Skip providers in health cooldown to avoid hammering overloaded endpoints
+    if (!ProviderHealthRegistry.getInstance().isAvailable(name)) {
+      return false;
     }
     if (name === "claude" || name === "anthropic") {
       return Boolean(


### PR DESCRIPTION
## Summary
- Adds a health gate in `prepareRequest()` that fails fast when **all** tracked providers are in cooldown, preventing delegation from spawning 15+ concurrent calls against overloaded providers (e.g., MiniMax HTTP 529).
- Adds a per-provider health check in `isDelegationProviderAvailable()` so dynamic tier routing skips unhealthy providers during candidate selection.
- Adds 4 unit tests covering: all-down rejection, partial-healthy passthrough, empty-registry passthrough, and per-provider availability gating.

## Test plan
- [x] All 101 delegation tests pass (`npx vitest run src/agents/multi/delegation/`)
- [x] New tests verify health gate blocks when all providers down
- [x] New tests verify delegation proceeds when at least one provider is healthy
- [x] New tests verify fresh registry (no entries) does not block
- [x] New tests verify `isDelegationProviderAvailable` returns false for down providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)